### PR TITLE
Potential fix for code scanning alert no. 11: Unsafe shell command constructed from library input

### DIFF
--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -181,11 +181,8 @@ export async function openDiff(
       case 'vim':
       case 'neovim': {
         // Use execSync for terminal-based editors
-        const command =
-          process.platform === 'win32'
-            ? `${diffCommand.command} ${diffCommand.args.join(' ')}`
-            : `${diffCommand.command} ${diffCommand.args.map((arg) => `"${arg}"`).join(' ')}`;
-        execSync(command, {
+        const args = diffCommand.args;
+        execFileSync(diffCommand.command, args, {
           stdio: 'inherit',
           encoding: 'utf8',
         });


### PR DESCRIPTION
Potential fix for [https://github.com/akabarki76/gemini-cli/security/code-scanning/11](https://github.com/akabarki76/gemini-cli/security/code-scanning/11)

To fix the issue:
1. Replace the use of `execSync` with `execFileSync`. The `execFileSync` API takes the command and arguments as separate parameters, avoiding shell interpretation entirely.
2. Refactor the code to construct the command using arrays for arguments rather than concatenating strings. This ensures that each argument is passed safely to the child process without risk of injection.
3. Remove the implementation of `args.map((arg) => ...)`, as it is no longer necessary when using `execFileSync`.

Changes should be made in the `openDiff` function starting on line 182, specifically for shell commands executed for terminal-based editors like `neovim`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
