### PR TITLE
Potential fix for code scanning alert no. 9: Unsafe shell command constructed from library input

### DIFF
--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -5,6 +5,7 @@
  */
 
 import { execSync, spawn } from 'child_process';
+import * as shellQuote from 'shell-quote';
 
 export type EditorType =
   | 'vscode'
@@ -126,8 +127,8 @@ export function getDiffCommand(
           // Auto close all windows when one is closed
           '-c',
           'autocmd WinClosed * wqa',
-          oldPath,
-          newPath,
+          shellQuote.quote([oldPath]),
+          shellQuote.quote([newPath]),
         ],
       };
     default:


### PR DESCRIPTION
Potential fix for [https://github.com/akabarki76/gemini-cli/security/code-scanning/9](https://github.com/akabarki76/gemini-cli/security/code-scanning/9)

To fix the issue, we need to ensure that `newPath` is properly escaped or sanitized before being passed to the shell command. The best approach is to use a library like `shell-quote` to escape special characters in `newPath` and other potentially unsafe inputs. This ensures that the shell interprets the arguments as literal strings rather than commands.

The changes will involve:
1. Importing the `shell-quote` library.
2. Escaping `newPath` and `oldPath` using `shellQuote.quote` before embedding them in the `args` array for the shell command.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
