### PR TITLE
Potential fix for code scanning alert no. 7: Unsafe shell command constructed from library input

### DIFF
--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -5,7 +5,6 @@
  */
 
 import { execSync, spawn } from 'child_process';
-import * as shellQuote from 'shell-quote';
 
 export type EditorType =
   | 'vscode'
@@ -174,7 +173,6 @@ export async function openDiff(
         return new Promise((resolve, reject) => {
           const childProcess = spawn(diffCommand.command, diffCommand.args, {
             stdio: 'inherit',
-            shell: true,
           });
 
           childProcess.on('close', (code) => {


### PR DESCRIPTION
Potential fix for [https://github.com/akabarki76/gemini-cli/security/code-scanning/7](https://github.com/akabarki76/gemini-cli/security/code-scanning/7)

The best way to fix this problem is to avoid using `{ shell: true }` in `spawn`, unless it is absolutely necessary. When `{ shell: true }` is not used, Node.js will pass each argument to the executable as a separate argument, eliminating the risk of shell interpretation and command injection. For GUI-based editors like VS Code, there is no need to use the shell unless the command relies on shell features (pipes, redirection, etc.), which is not the case here. Thus, we should remove `shell: true` from the `spawn` options in `openDiff`. No other code changes are required, since arguments are already being passed as an array.  
Additionally, the import for `shell-quote` on line 8 is unused and can be safely removed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
