### PR TITLE
Potential fix for code scanning alert no. 12: Unsafe shell command constructed from library input

### DIFF
--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -31,6 +31,7 @@ import {
   isCommandAllowed,
   stripShellWrapper,
 } from '../utils/shell-utils.js';
+import * as shellQuote from 'shell-quote';
 
 export const OUTPUT_UPDATE_INTERVAL_MS = 1000;
 
@@ -205,7 +206,7 @@ export class ShellTool extends BaseTool<ShellToolParams, ToolResult> {
         ? strippedCommand
         : (() => {
             // wrap command to append subprocess pids (via pgrep) to temporary file
-            let command = strippedCommand.trim();
+            let command = shellQuote.quote([strippedCommand.trim()]);
             if (!command.endsWith('&')) command += ';';
             return `{ ${command} }; __code=$?; pgrep -g 0 >${tempFilePath} 2>&1; exit $__code;`;
           })();


### PR DESCRIPTION
Potential fix for [https://github.com/akabarki76/gemini-cli/security/code-scanning/12](https://github.com/akabarki76/gemini-cli/security/code-scanning/12)

To fix the issue, we need to ensure that the `strippedCommand` input is properly escaped before embedding it into the shell command string. Since the shell interpretation is necessary (e.g., for handling pipes and redirections), we can use the `shell-quote` library to escape the input safely. This will prevent special characters in the input from being interpreted in a malicious way.

The fix involves:
1. Importing the `shell-quote` library.
2. Escaping the `strippedCommand` using `shellQuote.quote()` before embedding it into the shell command string on line 210.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
